### PR TITLE
[VT4SOC-37] Pin lua-resty-session to 3.10

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,4 +4,4 @@ author = Hans Zandbelt (@zandbelt), Stefan Bodewig (@bodewig)
 is_original = yes
 license = apache2
 repo_link = https://github.com/zmartzone/lua-resty-openidc
-requires = openresty, ledgetech/lua-resty-http >= 0.13, bungle/lua-resty-session >= 2.8, cdbattags/lua-resty-jwt >= 0.2.0
+requires = openresty, ledgetech/lua-resty-http >= 0.13, bungle/lua-resty-session = 3.10, cdbattags/lua-resty-jwt >= 0.2.0

--- a/lua-resty-openidc-1.7.6-2.rockspec
+++ b/lua-resty-openidc-1.7.6-2.rockspec
@@ -24,7 +24,7 @@ description = {
 dependencies = {
     "lua >= 5.1",
     "lua-resty-http >= 0.08",
-    "lua-resty-session >= 2.8, <4",
+    "lua-resty-session >= 2.8,< 3",
     "lua-resty-jwt >= 0.2.0"
 }
 build = {

--- a/lua-resty-openidc-1.7.6-2.rockspec
+++ b/lua-resty-openidc-1.7.6-2.rockspec
@@ -24,7 +24,7 @@ description = {
 dependencies = {
     "lua >= 5.1",
     "lua-resty-http >= 0.08",
-    "lua-resty-session >= 2.8",
+    "lua-resty-session >= 2.8, <4",
     "lua-resty-jwt >= 0.2.0"
 }
 build = {

--- a/lua-resty-openidc-1.7.6-2.rockspec
+++ b/lua-resty-openidc-1.7.6-2.rockspec
@@ -24,7 +24,7 @@ description = {
 dependencies = {
     "lua >= 5.1",
     "lua-resty-http >= 0.08",
-    "lua-resty-session >= 2.8,< 3",
+    "lua-resty-session = 3.10",
     "lua-resty-jwt >= 0.2.0"
 }
 build = {


### PR DESCRIPTION
lua-resty-session release a major version bump 4.0. 
This library took that dependency update since the dep was specified to take anything greater then 2.8. 
This change pins the lua-resty-session library to 3.10. 

4.0 is a breaking change. https://github.com/bungle/lua-resty-session